### PR TITLE
Use dynamic paths in PyInstaller specs

### DIFF
--- a/specs/linux.spec
+++ b/specs/linux.spec
@@ -1,12 +1,15 @@
 # -*- mode: python -*-
 
+import os
+
 block_cipher = None
 
+ROOT = os.path.abspath('.')
 
 a = Analysis(['run.py'],
-             pathex=['/home/mrf3/Projects/FQM'],
+             pathex=[ROOT],
              binaries=[],
-             datas=[('arabic_reshaper/*', 'arabic_reshaper')],
+             datas=[(os.path.join(ROOT, 'arabic_reshaper', '*'), 'arabic_reshaper')],
              hiddenimports=[
                 'app.gui', 'PyQt5', 'PyQt5.QtWidgets', 'email.mime.multipart', 'win32com.client',
                 'email.mime.message', 'email.mime.text', 'email.mime.image', 'email.mime.audio',
@@ -29,4 +32,4 @@ exe = EXE(pyz,
           strip=False,
           upx=True,
           console=False ,
-          icon='/home/mrf3/Projects/FQM/static/images/favicon.ico')
+          icon=os.path.join(ROOT, 'static', 'images', 'favicon.ico'))

--- a/specs/mac.spec
+++ b/specs/mac.spec
@@ -1,12 +1,15 @@
 # -*- mode: python -*-
 
+import os
+
 block_cipher = None
 
+ROOT = os.path.abspath('.')
 
 a = Analysis(['run.py'],
-             pathex=['/Users/mrf3/Documents/FQM'],
+             pathex=[ROOT],
              binaries=[],
-             datas=[('arabic_reshaper/*', 'arabic_reshaper')],
+             datas=[(os.path.join(ROOT, 'arabic_reshaper', '*'), 'arabic_reshaper')],
              hiddenimports=[
                 'app.gui', 'PyQt5', 'PyQt5.QtWidgets', 'email.mime.multipart', 'win32com.client',
                 'email.mime.message', 'email.mime.text', 'email.mime.image', 'email.mime.audio',
@@ -29,4 +32,4 @@ exe = EXE(pyz,
           strip=False,
           upx=True,
           console=False ,
-          icon='/Users/mrf3/Documents/FQM/static/images/favicon.ico')
+          icon=os.path.join(ROOT, 'static', 'images', 'favicon.ico'))

--- a/specs/win.spec
+++ b/specs/win.spec
@@ -15,7 +15,7 @@ ROOT = os.path.abspath('.')
 
 
 a = Analysis(['run.py'],
-             pathex=['C:\\Users\\tester\\Desktop\\fqm'],
+             pathex=[ROOT],
              binaries=[],
              datas=[(os.path.join(ROOT, 'arabic_reshaper', '*'), 'arabic_reshaper')],
              hiddenimports=[
@@ -40,4 +40,4 @@ exe = EXE(pyz,
           strip=False,
           upx=True,
           console=False ,
-          icon='C:\\Users\\tester\\Desktop\\fqm\\static\\images\\favicon.ico')
+          icon=os.path.join(ROOT, 'static', 'images', 'favicon.ico'))


### PR DESCRIPTION
## Summary
- make PyInstaller specs use project root for pathex
- build icon paths from ROOT for all OS specs

## Testing
- `pip install -r requirements/test.txt`
- `pip install gevent`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f174870483209346350692fa4443